### PR TITLE
Add configurable light transition time

### DIFF
--- a/adapters/rgbw_adapter.py
+++ b/adapters/rgbw_adapter.py
@@ -38,7 +38,7 @@ class RGBWAdapter(Adapter):
             blue = colorObject['b']
             color_temp = colorObject['t']
             cwww = colorObject['cw'] + colorObject['ww']
-            ttime = 1
+            ttime = light_transition_time   #'superglobal' variable stored in 'builtin' module called by plugin.py
             
             #only use cwww to determine mode
             if cwww == 0:
@@ -47,7 +47,7 @@ class RGBWAdapter(Adapter):
               # Disabled the transition time for now because hue bulb/zigbee2mqtt will
               # publish (acknowledge) the new color value during the transition with
               # a value between start and end of the transition, not the actual target color
-              #      "transition" : ttime,
+                    "transition" : ttime,
                     "brightness": int(level * 255 / 100),
                     "color": {
                         "r": red,
@@ -58,7 +58,7 @@ class RGBWAdapter(Adapter):
             else:
                 payload = json.dumps({
                     "state": "ON",
-               #     "transition" : ttime,
+                    "transition" : ttime,
                     "color_temp": int((color_temp / 255 * 346) + 154),
                     "brightness": int(level * 255 / 100)
                 })

--- a/plugin.py
+++ b/plugin.py
@@ -11,6 +11,7 @@
         <param field="Port" label="Port" width="300px" required="true" default="1883"/>
         <param field="Username" label="MQTT Username (optional)" width="300px" required="false" default=""/>
         <param field="Password" label="MQTT Password (optional)" width="300px" required="false" default="" password="true"/>
+        <param field="Mode4" label="Light transition time (sec)" width="30px" required="false" default="1"/>
         <param field="Mode3" label="MQTT Client ID (optional)" width="300px" required="false" default=""/>
         <param field="Mode1" label="Zigbee2Mqtt Topic" width="300px" required="true" default="zigbee2mqtt"/>
         <param field="Mode2" label="Zigbee pairing" width="75px" required="true">
@@ -33,6 +34,7 @@ import Domoticz
 import json
 import time
 import re
+import builtins
 from mqtt import MqttClient
 from zigbee_message import ZigbeeMessage
 from device_storage import DeviceStorage
@@ -53,6 +55,10 @@ class BasePlugin:
         self.base_topic = Parameters["Mode1"].strip()
         self.pairing_enabled = True if Parameters["Mode2"] == 'true' else False
         self.subscribed_for_devices = False
+        try:
+            builtins.light_transition_time = int(Parameters["Mode4"])
+        except:
+            builtins.light_transition_time = 1
 
         mqtt_server_address = Parameters["Address"].strip()
         mqtt_server_port = Parameters["Port"].strip()


### PR DESCRIPTION
I'm using the 'builtin' module to store the setting as a 'built in' variable. This is not the best/proper way, but I know of no other way to use a variable from the calling module in a imported module, other than passing the settings along when a module is called... Which would also mean adding the settings variable(s) in everywhere a imported class (every adapter, device and every module in between them and plugin.py). That seems too risky and a daunting task.

I will let you decide it this approach is acceptable or if (someone;-) should modify all files mentioned above ;-)